### PR TITLE
Expose relaxed test discovery as a nose plugin called `specselector`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     entry_points={
         'nose.plugins.0.10': [
             'spec = spec:SpecPlugin',
+            'specselector = spec.cli:CustomSelector',
         ],
         'console_scripts': [
             'spec = spec:main'

--- a/spec/cli.py
+++ b/spec/cli.py
@@ -111,10 +111,10 @@ class SpecSelector(nose.selector.Selector):
 # Plugin for loading selector & implementing some custom hooks too
 # (such as appending more test cases from gathered classes)
 class CustomSelector(nose.plugins.Plugin):
-    enabled = True
+    name = "specselector"
 
     def configure(self, options, conf):
-        pass
+        nose.plugins.Plugin.configure(self, options, conf)
 
     def prepareTestLoader(self, loader):
         loader.selector = SpecSelector(loader.config)


### PR DESCRIPTION
Invoke it with somthing like:

```
nosetests --with-specplugin --with-specselector tests
```

Then in another package that uses `spec` for tests, you can do:

```
(lexicon.venv)[last: 0] marca@scml-marca:~/dev/git-repos/lexicon$ grep test_suite setup.py
    test_suite='nose.collector',
(lexicon.venv)[last: 0] marca@scml-marca:~/dev/git-repos/lexicon$ cat setup.cfg
[nosetests]
with-specplugin = 1
with-specselector = 1
where = tests

[aliases]
test = nosetests
(lexicon.venv)[last: 0] marca@scml-marca:~/dev/git-repos/lexicon$ python setup.py nosetests
(lexicon.venv)[last: 0] marca@scml-marca:~/dev/git-repos/lexicon$ python setup.py test
```

and it works!
