### PR TITLE
Fixed a bug where doctests would result in .strip being called on a generator

### DIFF
--- a/spec/plugin.py
+++ b/spec/plugin.py
@@ -268,9 +268,9 @@ class SpecOutputStream(OutputStream):
         context._printed = True
 
     def print_spec(self, color_func, test, status=None):
-        spec = testDescription(test).strip()
+        spec = testDescription(test)
         if not isinstance(spec, types.GeneratorType):
-            spec = [spec]
+            spec = [spec.strip()]
         for s in spec:
             name = "- %s" % s
             paren = (" (%s)" % status) if status else ""


### PR DESCRIPTION
Using --spec-doctests would result in AttributeErrors since the function testDescription would return a generator. This should fix that. 